### PR TITLE
Implement more integration logic

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -4,6 +4,7 @@ import { WSMessageObject, WSMessageType } from "./utils/types";
 const {
   parseESP32TileGrid,
   parseTileGridShape,
+  constructWSObject,
 } = require("./utils/helpers.ts");
 
 const PORT = 3001;
@@ -11,12 +12,13 @@ const PORT = 3001;
 // Creating a new websocket server
 var wss = new WebSocketServer.Server({ port: PORT });
 var CLIENTS: WebSocketServer.WebSocket[] = [];
+var tileShapeStr = "m02013000002";
 
 // Creating connection using websocket
 // ws repreesnts one single client
 wss.on("connection", (ws) => {
   CLIENTS.push(ws);
-  broadcast("NEW USER JOINED", ws);
+  broadcast(WSMessageType.new_client, "NEW USER JOINED", ws);
 
   // EMITS EVERY SECOND TO ALL CLIENTS
   // setInterval(() => {
@@ -31,19 +33,33 @@ wss.on("connection", (ws) => {
     switch (messageObj.type) {
       case WSMessageType.led_pattern:
         console.log("[UI] LED PATTERN EMITTED");
-        broadcast(messageObj.data.toString(), ws);
+        broadcast(WSMessageType.led_pattern, messageObj.data.toString(), ws);
         break;
       case WSMessageType.request_sync_grid:
         console.log("[UI] REQUEST SYNC TILE GRID");
+        // ws.send(JSON.stringify(parseTileGridShape(tileShapeStr)));
+        var messageObjJSONStr: string = constructWSObject(
+          WSMessageType.request_sync_grid,
+          parseTileGridShape(tileShapeStr)
+        );
+        ws.send(messageObjJSONStr);
         break;
 
       case WSMessageType.send_sync_grid:
         console.log("[ESP32] SEND SYNC TILE GRID");
+        // var encodedStr: string = messageObj.data.toString();
+        broadcast(WSMessageType.send_sync_grid, tileShapeStr, ws);
+        broadcast(
+          WSMessageType.send_sync_grid,
+          parseTileGridShape(tileShapeStr),
+          ws
+        );
+
         break;
 
       case WSMessageType.pressure_data:
         console.log("[ESP32] PRESSURE DATA EMITTED");
-        broadcast(data.toString(), ws);
+        broadcast(WSMessageType.pressure_data, data.toString(), ws);
         console.log(WSMessageType.pressure_data);
         break;
 
@@ -62,25 +78,30 @@ wss.on("connection", (ws) => {
 });
 console.log(`The WebSocket server is running on port ${PORT}`);
 
-parseESP32TileGrid("1 2 3 4 5 6 7 8");
-// parseTileGridShape("123"); //Invalid
-// parseTileGridShape("1234"); //Invalid
-// parseTileGridShape("m02013000002");
-// parseTileGridShape("m03000031200");
-// parseTileGridShape("m02010302000");
-
 function sendAll(message: string) {
   for (var i = 0; i < CLIENTS.length; i++) {
     CLIENTS[i].send("> SERVER: " + message);
+    sendWSObject(WSMessageType.alert, "> SERVER: " + message, CLIENTS[i]);
   }
 }
 
-function broadcast(data: string, senderWS: WebSocketServer.WebSocket) {
+function broadcast(
+  type: WSMessageType,
+  data: string,
+  senderWS: WebSocketServer.WebSocket
+) {
   wss.clients.forEach(function (client) {
-    if (client !== senderWS) client.send(data);
-    else client.send("Received Data");
+    if (client !== senderWS) sendWSObject(type, data, client);
   });
   console.log("Broadcast: ", data.toString());
+}
+
+function sendWSObject(
+  type: WSMessageType,
+  data: string,
+  ws: WebSocketServer.WebSocket
+): void {
+  ws.send(constructWSObject(type, data));
 }
 
 export {};

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,4 +1,0 @@
-export enum WSMessageType {
-  sync_grid = "sync_grid",
-  led_pattern = "led_pattern",
-}

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -1,4 +1,10 @@
-import { ArrayOperation, ArrayManipulation } from "./types";
+import {
+  ArrayOperation,
+  ArrayManipulation,
+  WSMessageType,
+  WSMessageObject,
+} from "./types";
+import WebSocketServer = require("ws");
 
 /**
  * This function parses the incoming string from the esp32
@@ -297,7 +303,13 @@ const modifyArray = (
   }
 };
 
+const constructWSObject = (type: WSMessageType, data: string): string => {
+  const obj: WSMessageObject = { type: type, data: data };
+  return JSON.stringify(obj);
+};
+
 module.exports = {
   parseESP32TileGrid: parseESP32TileGrid,
   parseTileGridShape: parseTileGridShape,
+  constructWSObject: constructWSObject,
 };

--- a/server/utils/helpers.ts
+++ b/server/utils/helpers.ts
@@ -83,7 +83,7 @@ interface HashTable<T> {
 const parseTileGridShape = (str: string) => {
   const strArray: string[] = str.split("");
 
-  var grid: string[][];
+  var grid: number[][];
   var tileCoordinates: HashTable<Array<number>> = {};
   var tilePositions: string[][] = [];
   var currentCoords: number[] = [0, 0];
@@ -224,7 +224,7 @@ const parseTileGridShape = (str: string) => {
   for (const tile in tileCoordinates) {
     let x = tileCoordinates[tile][0];
     let y = tileCoordinates[tile][1];
-    grid[gridHeight - y][x] = tile;
+    grid[gridHeight - y][x] = parseInt(tile);
   }
 
   return grid;

--- a/server/utils/types.ts
+++ b/server/utils/types.ts
@@ -26,6 +26,8 @@ export enum WSMessageType {
   send_sync_grid = "send_sync_grid", // [ESP32]
   led_pattern = "led_pattern", // [UI]
   pressure_data = "pressure_data", // [ESP32]
+  alert = "alert",
+  new_client = "new_client",
 }
 
 export interface WSMessageObject {

--- a/server/utils/types.ts
+++ b/server/utils/types.ts
@@ -16,3 +16,19 @@ export enum ArrayOperation {
   before = "before",
   after = "after",
 }
+
+/**
+ * SHARED DATA TYPES BETWEEN FRONTEND AND SERVER
+ */
+// TODO: Find a way to share these types bt frontend and backend
+export enum WSMessageType {
+  request_sync_grid = "request_sync_grid", // [UI]
+  send_sync_grid = "send_sync_grid", // [ESP32]
+  led_pattern = "led_pattern", // [UI]
+  pressure_data = "pressure_data", // [ESP32]
+}
+
+export interface WSMessageObject {
+  type: WSMessageType;
+  data: Object;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,11 +13,7 @@ import {
 import { useState } from "react";
 import { PlaygroundMode } from "./components/types/types";
 import { useRouteLocation } from "./components/hooks/useRouteLocation";
-import {
-  mockDrawModeTileGrid,
-  mockProgramModeTileGrid,
-} from "./mockData/mockTileObject";
-import { mockDataStream } from "./mockData/mockInput";
+import { mockProgramModeTileGrid } from "./mockData/mockTileObject";
 
 // TODO: Initialize a MFFFFFFFFFFFF DRAW MODE TILE GRID
 function App() {

--- a/src/components/hooks/useDrawModeContext.ts
+++ b/src/components/hooks/useDrawModeContext.ts
@@ -21,5 +21,9 @@ export const useDrawModeContext = () => {
     );
   };
 
-  return [updateTileGridObject];
+  const clearDrawModeContext = () => {
+    setTileGridObject([]);
+  };
+
+  return { updateTileGridObject, clearDrawModeContext };
 };

--- a/src/components/hooks/useProgramModeContext.tsx
+++ b/src/components/hooks/useProgramModeContext.tsx
@@ -162,6 +162,10 @@ export const useProgramModeContext = () => {
   const initializeTempTileGridObject = (tileGridObject: TileGridObject) => {
     setTempTileGridObject(tileGridObject);
   };
+
+  const clearProgramModeContext = () => {
+    setProgramModeStates([]);
+  };
   return {
     updateProgramModeStates,
     createProgramModeState,
@@ -169,5 +173,6 @@ export const useProgramModeContext = () => {
     deleteStateObjectById,
     updateTempTileGridObject,
     initializeTempTileGridObject,
+    clearProgramModeContext,
   };
 };

--- a/src/components/shared/Sidebar/Sidebar.tsx
+++ b/src/components/shared/Sidebar/Sidebar.tsx
@@ -3,6 +3,8 @@ import { modifiedMockDrawModeTileGrid } from "../../../mockData/mockTileObject";
 import { encodeTileGrid, getLocalStorageItem } from "../../../utils/helpers";
 import { emitLEDPattern, syncTileGrid } from "../../../utils/socket";
 import { HorizontalDivider } from "../../Containers";
+import { useDrawModeContext } from "../../hooks/useDrawModeContext";
+import { useProgramModeContext } from "../../hooks/useProgramModeContext";
 import { useRouteLocation } from "../../hooks/useRouteLocation";
 import {
   LocalStorageKeys,
@@ -38,10 +40,14 @@ const UpperContainer = styled.div`
 
 const Sidebar = () => {
   const [playgroundRoute] = useRouteLocation();
+  const { clearProgramModeContext } = useProgramModeContext();
+  const { clearDrawModeContext } = useDrawModeContext();
 
   const onSync = () => {
     if (window.confirm("This action will reset all your states")) {
       console.log("Sync everything");
+      clearProgramModeContext();
+      clearDrawModeContext();
       syncTileGrid();
     } else {
       console.log("User cancelled");

--- a/src/components/shared/Sidebar/Sidebar.tsx
+++ b/src/components/shared/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
-import { mockDrawModeTileGridDiff } from "../../../mockData/mockTileObject";
+import { modifiedMockDrawModeTileGrid } from "../../../mockData/mockTileObject";
 import { encodeTileGrid, getLocalStorageItem } from "../../../utils/helpers";
-import { syncTileGrid } from "../../../utils/socket";
+import { emitLEDPattern, syncTileGrid } from "../../../utils/socket";
 import { HorizontalDivider } from "../../Containers";
 import { useRouteLocation } from "../../hooks/useRouteLocation";
 import {
@@ -54,7 +54,7 @@ const Sidebar = () => {
     );
 
     // TODO: Use actual new grid
-    console.log(encodeTileGrid(tileGridObj, mockDrawModeTileGridDiff()));
+    emitLEDPattern(tileGridObj, modifiedMockDrawModeTileGrid);
   };
 
   return (

--- a/src/components/shared/Sidebar/SidebarDrawMode.tsx
+++ b/src/components/shared/Sidebar/SidebarDrawMode.tsx
@@ -3,7 +3,7 @@ import { Color } from "../../types/types";
 import ColorPicker from "../ColorPicker/ColorPicker";
 
 const SidebarDrawMode = () => {
-  const [updateTileGridObject] = useDrawModeContext();
+  const { updateTileGridObject } = useDrawModeContext();
 
   const onSetColor = (
     e: React.MouseEvent<HTMLButtonElement, MouseEvent>,

--- a/src/components/shared/Sidebar/TempComp.tsx
+++ b/src/components/shared/Sidebar/TempComp.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { w3cwebsocket as W3CWebSocket } from "websocket";
 import { getLocalStorageItem } from "../../../utils/helpers";
-import { wsClient } from "../../../utils/socket";
+import { onMessage, wsClient } from "../../../utils/socket";
 import { LocalStorageKeys } from "../../types/types";
 
 const TempComp = () => {
@@ -12,7 +12,9 @@ const TempComp = () => {
     };
     wsClient.onmessage = (event) => {
       setMessage(JSON.stringify(event.data));
-      console.log(event.data);
+      setMessage(JSON.parse(JSON.stringify(event.data)));
+      onMessage(event);
+      console.log(event);
     };
   });
 

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -135,6 +135,8 @@ export enum WSMessageType {
   send_sync_grid = "send_sync_grid", // [ESP32]
   led_pattern = "led_pattern", // [UI]
   pressure_data = "pressure_data", // [ESP32]
+  alert = "alert",
+  new_client = "new_client",
 }
 
 export interface WSMessageObject {

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -129,9 +129,12 @@ export type DStreamTileShape = number[][];
 /**
  * WEB SOCKET RELATED
  */
+// TODO: Find a way to share these types bt frontend and backend
 export enum WSMessageType {
-  sync_grid = "sync_grid",
-  led_pattern = "led_pattern",
+  request_sync_grid = "request_sync_grid", // [UI]
+  send_sync_grid = "send_sync_grid", // [ESP32]
+  led_pattern = "led_pattern", // [UI]
+  pressure_data = "pressure_data", // [ESP32]
 }
 
 export interface WSMessageObject {

--- a/src/components/types/types.ts
+++ b/src/components/types/types.ts
@@ -109,6 +109,29 @@ export interface TileIdObject {
  * ---------------------------------------------------------------------
  */
 
+/**
+ * NEED TO DELETE ALL OF THESE BELOW
+ */
+export type DStreamTileGridObject = Array<DstreamTileRowObject>;
+export type DstreamTileRowObject = Array<DStreamTileObject>;
+
+export interface DStreamTileObject {
+  tileId: string | "empty";
+  pressureData: PressureDataObject;
+  pressureValue: number;
+}
+
+export interface PressureDataObject {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * NEED TO DELETE ALL OF THESE ABOVE
+ */
+
 export type DStreamTileGridPressure = Array<DStreamPressureObject>;
 
 // Tile grid object for the incoming data stream from the ESP32
@@ -141,5 +164,5 @@ export enum WSMessageType {
 
 export interface WSMessageObject {
   type: WSMessageType;
-  data: Object;
+  data: any;
 }

--- a/src/mockData/mockTileObject.ts
+++ b/src/mockData/mockTileObject.ts
@@ -214,7 +214,7 @@ export var mockDrawModeTileGrid: TileGridObject = [
   ],
 ];
 
-export const mockDrawModeTileGridDiff = () => {
+const modifyMockDrawModeTileGrid = () => {
   var modifiedGrid = JSON.parse(JSON.stringify(mockDrawModeTileGrid));
   modifiedGrid[0][0].ledConfig = [
     [
@@ -245,6 +245,8 @@ export const mockDrawModeTileGridDiff = () => {
 
   return modifiedGrid;
 };
+
+export const modifiedMockDrawModeTileGrid = modifyMockDrawModeTileGrid();
 
 export const mockProgramModeTileGrid: TileGridObject = [
   [

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,10 +1,24 @@
-import { StateOperator } from "../components/types/types";
+import {
+  Color,
+  LEDConfig,
+  LEDRowT,
+  SingleLEDPattern,
+  StateOperator,
+} from "../components/types/types";
 
 export const MAX_PRESSURE_SENSOR_VALUE = 255;
 
 // TILE GRID
 export const TILE_CANVAS_ID = "tile-canvas-container";
 export const TILE_CONTAINER_CLASSNAME = "tile-container";
+
+// TILE GRID OBJ INITIALIZATION
+export const defaultLEDPattern: SingleLEDPattern = {
+  color: Color.none,
+  opacity: 100,
+};
+export const defaultLEDRow: LEDRowT = Array(4).fill(defaultLEDPattern);
+export const defaultLEDConfig: LEDConfig = Array(4).fill(defaultLEDRow);
 
 // LOCAL STORAGE
 export const DRAW_MODE_TILE_GRID_LS_OBJ = "tileGridDrawMode";
@@ -25,3 +39,6 @@ export const DROPDOWN_OPTIONS = [
   StateOperator.notEqualTo,
   StateOperator.between,
 ];
+
+// WEBSOCKETS
+export const RGB_STR_PADDING = 3;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -64,6 +64,10 @@ export const setLocalStorageItem = (
   localStorage.setItem(localStorageKey, JSON.stringify(object));
 };
 
+export const removeLocalStorageItem = (localStorageKey: LocalStorageKey) => {
+  localStorage.removeItem(localStorageKey);
+};
+
 /**
  * ---------------------------------------------------
  * INTERFACE COLOR CHANGING LOGIC
@@ -500,5 +504,5 @@ export const encodeTileGrid = (
     }
   }
 
-  return encodedString;
+  return encodedString.trim();
 };

--- a/src/utils/socket.ts
+++ b/src/utils/socket.ts
@@ -1,32 +1,49 @@
 import { w3cwebsocket as W3CWebSocket } from "websocket";
 import {
+  LocalStorageKeys,
   TileGridObject,
   WSMessageObject,
   WSMessageType,
 } from "../components/types/types";
+import { encodeTileGrid, removeLocalStorageItem } from "./helpers";
 
 const HOST = "192.168.0.41";
 const IPHONE_HOTSPOT = "172.20.10.2";
 const UBC_SECURE = "128.189.131.17";
+const SONG_LING = "192.168.50.71";
 const PORT = 3001;
 
-export const wsClient = new W3CWebSocket(`ws://${UBC_SECURE}:${PORT}`);
+export const wsClient = new W3CWebSocket(`ws://${SONG_LING}:${PORT}`);
 
-const constructWSObject = (
-  type: WSMessageType,
-  data: Object
-): WSMessageObject => {
-  return { type: type, data: data };
+const constructWSObject = (type: WSMessageType, data: string): string => {
+  const obj: WSMessageObject = { type: type, data: data };
+  return JSON.stringify(obj);
 };
 
 export const syncTileGrid = () => {
   const messageObj: WSMessageObject = {
-    type: WSMessageType.sync_grid,
-    data: {},
+    type: WSMessageType.request_sync_grid,
+    data: "",
   };
   wsClient.send(JSON.stringify(messageObj));
+  removeLocalStorageItem(LocalStorageKeys.DRAW_MODE_TILE_GRID_LS_OBJ);
+  removeLocalStorageItem(LocalStorageKeys.PROGRAM_MODE_STATES_LIST_LS_OBJ);
+  removeLocalStorageItem(LocalStorageKeys.PROGRAM_MODE_TILE_GRID_LS_OBJ);
 };
 
-export const emitLEDPattern = (tileGridObj: TileGridObject) => {
-  wsClient.send(constructWSObject(WSMessageType.led_pattern, tileGridObj));
+export const emitLEDPattern = (
+  ogTileGrid: TileGridObject,
+  newTileGrid: TileGridObject
+) => {
+  var obj = constructWSObject(
+    WSMessageType.led_pattern,
+    encodeTileGrid(ogTileGrid, newTileGrid)
+  );
+  console.log("sending this: ", obj);
+  wsClient.send(
+    constructWSObject(
+      WSMessageType.led_pattern,
+      encodeTileGrid(ogTileGrid, newTileGrid)
+    )
+  );
 };

--- a/src/utils/socket.ts
+++ b/src/utils/socket.ts
@@ -1,4 +1,4 @@
-import { w3cwebsocket as W3CWebSocket } from "websocket";
+import { IMessageEvent, w3cwebsocket as W3CWebSocket } from "websocket";
 import {
   LocalStorageKeys,
   TileGridObject,
@@ -21,11 +21,8 @@ const constructWSObject = (type: WSMessageType, data: string): string => {
 };
 
 export const syncTileGrid = () => {
-  const messageObj: WSMessageObject = {
-    type: WSMessageType.request_sync_grid,
-    data: "",
-  };
-  wsClient.send(JSON.stringify(messageObj));
+  const messageStr = constructWSObject(WSMessageType.request_sync_grid, "");
+  wsClient.send(messageStr);
   removeLocalStorageItem(LocalStorageKeys.DRAW_MODE_TILE_GRID_LS_OBJ);
   removeLocalStorageItem(LocalStorageKeys.PROGRAM_MODE_STATES_LIST_LS_OBJ);
   removeLocalStorageItem(LocalStorageKeys.PROGRAM_MODE_TILE_GRID_LS_OBJ);
@@ -35,15 +32,38 @@ export const emitLEDPattern = (
   ogTileGrid: TileGridObject,
   newTileGrid: TileGridObject
 ) => {
-  var obj = constructWSObject(
+  var messageStr = constructWSObject(
     WSMessageType.led_pattern,
     encodeTileGrid(ogTileGrid, newTileGrid)
   );
-  console.log("sending this: ", obj);
-  wsClient.send(
-    constructWSObject(
-      WSMessageType.led_pattern,
-      encodeTileGrid(ogTileGrid, newTileGrid)
-    )
-  );
+  console.log("sending this: ", messageStr);
+  wsClient.send(messageStr);
+};
+
+export const onMessage = (event: IMessageEvent) => {
+  console.log("DATA: ", event.data);
+  var messageStr = JSON.stringify(event.data);
+  var messageObj: WSMessageObject = JSON.parse(messageStr);
+  switch (messageObj.type) {
+    case WSMessageType.led_pattern:
+      console.log("[UI] LED PATTERN EMITTED");
+      break;
+    case WSMessageType.request_sync_grid:
+      console.log("[UI] REQUEST SYNC TILE GRID");
+      break;
+
+    case WSMessageType.send_sync_grid:
+      console.log("[ESP32] SEND SYNC TILE GRID");
+      // var encodedStr: string = messageObj.data.toString();
+
+      break;
+
+    case WSMessageType.pressure_data:
+      console.log("[ESP32] PRESSURE DATA EMITTED");
+      console.log(WSMessageType.pressure_data);
+      break;
+
+    default:
+      break;
+  }
 };

--- a/src/utils/socket.ts
+++ b/src/utils/socket.ts
@@ -5,7 +5,11 @@ import {
   WSMessageObject,
   WSMessageType,
 } from "../components/types/types";
-import { encodeTileGrid, removeLocalStorageItem } from "./helpers";
+import {
+  encodeTileGrid,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from "./helpers";
 
 const HOST = "192.168.0.41";
 const IPHONE_HOTSPOT = "172.20.10.2";
@@ -13,7 +17,7 @@ const UBC_SECURE = "128.189.131.17";
 const SONG_LING = "192.168.50.71";
 const PORT = 3001;
 
-export const wsClient = new W3CWebSocket(`ws://${SONG_LING}:${PORT}`);
+export const wsClient = new W3CWebSocket(`ws://${HOST}:${PORT}`);
 
 const constructWSObject = (type: WSMessageType, data: string): string => {
   const obj: WSMessageObject = { type: type, data: data };
@@ -43,13 +47,20 @@ export const emitLEDPattern = (
 export const onMessage = (event: IMessageEvent) => {
   console.log("DATA: ", event.data);
   var messageStr = JSON.stringify(event.data);
-  var messageObj: WSMessageObject = JSON.parse(messageStr);
+  var messageObj: WSMessageObject = JSON.parse(JSON.parse(messageStr));
+  console.log("FUlly parsed: ", messageObj);
   switch (messageObj.type) {
     case WSMessageType.led_pattern:
       console.log("[UI] LED PATTERN EMITTED");
       break;
     case WSMessageType.request_sync_grid:
       console.log("[UI] REQUEST SYNC TILE GRID");
+      var tileShape: number[][] = messageObj.data;
+      console.log("My shape: ", tileShape);
+      // setLocalStorageItem(
+      //   LocalStorageKeys.DRAW_MODE_TILE_GRID_LS_OBJ,
+      //   messageObj.data
+      // );
       break;
 
     case WSMessageType.send_sync_grid:


### PR DESCRIPTION
- Add more WSMessage types to help server broadcast/emit data accordingly
- Ensure type safety for all these events
- Implement `emitLEDPattern` which sends the LED pattern data to the websocket with a properly formatted WS object
- Abstracted `ws.send` to `sendWSObject` so we can ensure type safety and correct formatting when sending from UI
- Fixes a bug where the tile grid shape being sent from the WS server was composed of a mix of strings and numbers
- Add hook functions to clear all context values
- Add a padding option  (as per @Cyclical- 's request) so that rgb values are shown like: 001 020 255 because Arduino doesn't have an equivalent to string.split(" ");