### PR TITLE
[BUG FIX] Selecto Selection Bug

### DIFF
--- a/src/components/context/drawModeContext.tsx
+++ b/src/components/context/drawModeContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, ReactChild, useContext, useState } from "react";
-import { TileGridObject } from "../../utils/types";
+import { getLocalStorageItem } from "../../utils/helpers";
+import { LocalStorageKeys, TileGridObject } from "../../utils/types";
 import { GlobalContext } from "./globalContext";
 
 interface DrawModeContextProps {
@@ -19,7 +20,10 @@ interface IDrawModeContextProvider {
 export const DrawModeContextProvider = (props: IDrawModeContextProvider) => {
   const { globalTileGridObject } = useContext(GlobalContext);
   const [drawModeTileGridObject, setDrawModeTileGridObject] =
-    useState<TileGridObject>(globalTileGridObject);
+    useState<TileGridObject>(
+      getLocalStorageItem(LocalStorageKeys.DRAW_MODE_TILE_GRID_LS_OBJ) ||
+        globalTileGridObject
+    );
   const tileGridContextValue = {
     drawModeTileGridObject,
     setDrawModeTileGridObject,

--- a/src/components/context/globalContext.tsx
+++ b/src/components/context/globalContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, ReactChild, useState } from "react";
+import { createContext, ReactChild, RefObject, useState } from "react";
+import Selecto, { OnSelect } from "react-selecto";
 import { getLocalStorageItem } from "../../utils/helpers";
 import { LocalStorageKeys, TileGridObject } from "../../utils/types";
 
@@ -6,11 +7,15 @@ import { LocalStorageKeys, TileGridObject } from "../../utils/types";
 export interface GlobalContextProps {
   globalTileGridObject: TileGridObject;
   setGlobalTileGridObject: (obj: TileGridObject) => void;
+  selectoRef: RefObject<Selecto> | null;
+  setSelectoRef: (e: RefObject<Selecto>) => void;
 }
 
 export const GlobalContext = createContext<GlobalContextProps>({
   globalTileGridObject: [],
   setGlobalTileGridObject: () => {},
+  selectoRef: null,
+  setSelectoRef: () => {},
 });
 
 interface IGlobalContextProvider {
@@ -22,9 +27,14 @@ export const GlobalContextProvider = (props: IGlobalContextProvider) => {
     useState<TileGridObject>(
       getLocalStorageItem(LocalStorageKeys.GLOBAL_TILE_GRID_LS_OBJ || [])
     );
+  const [selectoEvent, setSelectoEvent] = useState<RefObject<Selecto> | null>(
+    null
+  );
   const globalContextValue: GlobalContextProps = {
-    globalTileGridObject: globalTileGridObject,
-    setGlobalTileGridObject: setGlobalTileGridObject,
+    globalTileGridObject,
+    setGlobalTileGridObject,
+    selectoRef: selectoEvent,
+    setSelectoRef: setSelectoEvent,
   };
   return (
     <GlobalContext.Provider value={globalContextValue}>

--- a/src/components/hooks/useDrawModeContext.ts
+++ b/src/components/hooks/useDrawModeContext.ts
@@ -5,8 +5,11 @@ import {
 } from "../../utils/helpers";
 import { DrawModeContext } from "../context/drawModeContext";
 import { Color, LocalStorageKeys } from "../../utils/types";
+import { GlobalContext } from "../context/globalContext";
+import Selecto from "react-selecto";
 
 export const useDrawModeContext = () => {
+  const { selectoRef } = useContext(GlobalContext);
   const {
     drawModeTileGridObject: tileGridObject,
     setDrawModeTileGridObject: setTileGridObject,
@@ -19,9 +22,7 @@ export const useDrawModeContext = () => {
       LocalStorageKeys.DRAW_MODE_TILE_GRID_LS_OBJ,
       updatedTileGridObject
     );
-    Array.from(document.querySelectorAll(".led")).forEach((el) =>
-      el.classList.remove("selected")
-    );
+    selectoRef?.current?.setSelectedTargets([]);
   };
 
   const clearDrawModeContext = () => {

--- a/src/components/hooks/useProgramModeContext.tsx
+++ b/src/components/hooks/useProgramModeContext.tsx
@@ -15,6 +15,7 @@ import {
   TileGridObject,
   TileIdObject,
 } from "../../utils/types";
+import { GlobalContext } from "../context/globalContext";
 
 export const useProgramModeContext = () => {
   const {
@@ -23,6 +24,7 @@ export const useProgramModeContext = () => {
     tempTileGridObject,
     setTempTileGridObject,
   } = useContext(ProgramModeContext);
+  const { selectoRef } = useContext(GlobalContext);
 
   // INTERNAL UTILITY FUNCTIONS
   const clearTempTileGridObject = () => {
@@ -67,9 +69,8 @@ export const useProgramModeContext = () => {
       LocalStorageKeys.PROGRAM_MODE_STATES_LIST_LS_OBJ,
       deepCopyProgramModeStates
     );
-    Array.from(document.querySelectorAll(".led")).forEach((el) =>
-      el.classList.remove("selected")
-    );
+    selectoRef?.current?.setSelectedTargets([]);
+
     clearTempTileGridObject();
   };
 
@@ -105,9 +106,7 @@ export const useProgramModeContext = () => {
       newStateObject,
     ]);
     clearTempTileGridObject();
-    Array.from(document.querySelectorAll(".led")).forEach((el) =>
-      el.classList.remove("selected")
-    );
+    selectoRef?.current?.setSelectedTargets([]);
   };
 
   /**
@@ -153,10 +152,9 @@ export const useProgramModeContext = () => {
       color,
       tempTileGridObject
     );
+    console.log(updatedTileGridObject);
     setTempTileGridObject(updatedTileGridObject);
-    Array.from(document.querySelectorAll(".led")).forEach((el) =>
-      el.classList.remove("selected")
-    );
+    selectoRef?.current?.setSelectedTargets([]);
   };
 
   const initializeTempTileGridObject = (tileGridObject: TileGridObject) => {

--- a/src/components/pages/Playground/DrawModeTileCanvas.tsx
+++ b/src/components/pages/Playground/DrawModeTileCanvas.tsx
@@ -1,6 +1,6 @@
 import Tile from "../../shared/Tile/Tile";
 import Selecto, { OnSelect } from "react-selecto";
-import { useContext } from "react";
+import { useContext, useEffect, useRef } from "react";
 import { DrawModeContext } from "../../context/drawModeContext";
 import { convertNumberToLetter } from "../../../utils/helpers";
 import { TileIdObject } from "../../../utils/types";
@@ -11,11 +11,18 @@ import {
   TileNumberContainer,
   TileRowContainer,
 } from "../../Containers";
+import { GlobalContext } from "../../context/globalContext";
 
 // TODO: LED selection bug
 const DrawModeTileCanvas = () => {
   const { drawModeTileGridObject: tileGridObject } =
     useContext(DrawModeContext);
+  const { selectoRef, setSelectoRef } = useContext(GlobalContext);
+  const ref = useRef<Selecto>(null);
+
+  useEffect(() => {
+    setSelectoRef(ref);
+  }, []);
   const onSelect: any = (e: OnSelect<Selecto>) => {
     e.added.forEach((el) => {
       el.classList.add("selected");
@@ -30,7 +37,7 @@ const DrawModeTileCanvas = () => {
       <Selecto
         container={document.getElementById(TILE_CANVAS_ID)}
         dragContainer={document.getElementById(TILE_CANVAS_ID) || window}
-        selectableTargets={[".led"]}
+        selectableTargets={[".led", `.${TILE_CANVAS_ID}`]}
         selectFromInside={false}
         continueSelect={true}
         toggleContinueSelect={"shift"}
@@ -38,6 +45,7 @@ const DrawModeTileCanvas = () => {
         hitRate={20}
         onSelect={onSelect}
         selectByClick={true}
+        ref={selectoRef}
       />
       {tileGridObject.map((tileRow, rowIndex) => {
         return (

--- a/src/components/pages/Playground/ProgramMode.tsx
+++ b/src/components/pages/Playground/ProgramMode.tsx
@@ -5,14 +5,6 @@ import {
 import Sidebar from "../../shared/Sidebar/Sidebar";
 import ProgramModeTileCanvas from "./ProgramModeTileCanvas";
 
-// const mockProgramModeState: ProgramModeStateObject = {
-//   color: Color.blue,
-//   id: "1",
-//   operator: StateOperator.greaterThan,
-//   primaryInputValue: 200,
-//   selectedLEDs: ["hello"],
-// };
-
 const ProgramMode = () => {
   return (
     <FullWidthHeightCenteredContainer>

--- a/src/components/pages/Playground/ProgramModeTileCanvas.tsx
+++ b/src/components/pages/Playground/ProgramModeTileCanvas.tsx
@@ -1,6 +1,6 @@
 import Tile from "../../shared/Tile/Tile";
 import Selecto, { OnSelect } from "react-selecto";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { convertNumberToLetter } from "../../../utils/helpers";
 import { TileIdObject } from "../../../utils/types";
@@ -12,6 +12,7 @@ import {
 } from "../../Containers";
 import { TILE_CANVAS_ID } from "../../../utils/constants";
 import { ProgramModeContext } from "../../context/programModeContext";
+import { GlobalContext } from "../../context/globalContext";
 
 // TODO: LED selection bug
 const ProgramModeTileCanvas = () => {
@@ -19,6 +20,12 @@ const ProgramModeTileCanvas = () => {
   const [isSelecting, setIsSelecting] = useState(false);
   const { tempTileGridObject } = useContext(ProgramModeContext);
   const [dragContainer, setDragContainer] = useState<HTMLElement | null>();
+  const { selectoRef, setSelectoRef } = useContext(GlobalContext);
+  const ref = useRef<Selecto>(null);
+
+  useEffect(() => {
+    setSelectoRef(ref);
+  }, []);
 
   useEffect(() => {
     if (location.pathname.split("/").length === 4) {
@@ -53,6 +60,7 @@ const ProgramModeTileCanvas = () => {
         keyContainer={document.getElementById(TILE_CANVAS_ID)}
         hitRate={20}
         onSelect={onSelect}
+        ref={selectoRef}
       />
       {tempTileGridObject !== [] &&
         tempTileGridObject.map((tileRow, rowIndex) => {


### PR DESCRIPTION
This PR fixes this problem:
1. Select X LEDs
2. Set the LED color
3. [ERROR] Try to reselect the LEDs

Upon trying to reselect these LEDs, the software seems to think that these elements need to be removed.

Previously, I was jQuery to remove the "selected" class to all HTML elements, but this does not clear the internally stored "added" or "removed" list of components in Selecto.

The fix was to add store a ref, `selectoRef` in the `GlobalContext` and use that ref to reset the currently selected targets.