### PR TITLE
[BUG FIX]

### DIFF
--- a/src/components/hooks/useDrawModeContext.ts
+++ b/src/components/hooks/useDrawModeContext.ts
@@ -6,7 +6,6 @@ import {
 import { DrawModeContext } from "../context/drawModeContext";
 import { Color, LocalStorageKeys } from "../../utils/types";
 import { GlobalContext } from "../context/globalContext";
-import Selecto from "react-selecto";
 
 export const useDrawModeContext = () => {
   const { selectoRef } = useContext(GlobalContext);

--- a/src/components/pages/Playground/DrawModeTileCanvas.tsx
+++ b/src/components/pages/Playground/DrawModeTileCanvas.tsx
@@ -22,6 +22,7 @@ const DrawModeTileCanvas = () => {
 
   useEffect(() => {
     setSelectoRef(ref);
+    console.log(ref);
   }, []);
   const onSelect: any = (e: OnSelect<Selecto>) => {
     e.added.forEach((el) => {
@@ -36,7 +37,6 @@ const DrawModeTileCanvas = () => {
     <TileCanvasContainer id={TILE_CANVAS_ID}>
       <Selecto
         container={document.getElementById(TILE_CANVAS_ID)}
-        dragContainer={document.getElementById(TILE_CANVAS_ID) || window}
         selectableTargets={[".led", `.${TILE_CANVAS_ID}`]}
         selectFromInside={false}
         continueSelect={true}

--- a/src/components/pages/Playground/ProgramModeTileCanvas.tsx
+++ b/src/components/pages/Playground/ProgramModeTileCanvas.tsx
@@ -52,7 +52,6 @@ const ProgramModeTileCanvas = () => {
     <TileCanvasContainer id={TILE_CANVAS_ID}>
       <Selecto
         container={document.getElementById(TILE_CANVAS_ID)}
-        dragContainer={document.getElementById(TILE_CANVAS_ID) || window}
         selectableTargets={[".led"]}
         continueSelect={true}
         selectByClick={true}


### PR DESCRIPTION
This PR fixes a problem where if you navigated away from the component that had the `<Selecto/>` component and came back, you couldn't select LEDs anymore until you refreshed it.

IT WAS FIXED BY LITERALLY REMOVING THE `draggableContainer` param from the `<Selecto/>` component SMH